### PR TITLE
Switch base image to maintained one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sbani/google-gloud-sdk:latest
+FROM google/cloud-sdk:alpine
 
 RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
      apk update && \


### PR DESCRIPTION
In order to use more recent docker (which supports --cache-from flag) we need to switch base image.