### PR TITLE
It prompts for a y/n question midst installing this is a by pass

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM google/cloud-sdk:alpine
 
 ENV VAULT_VERSION=0.11.0
 
-RUN gcloud components install kubectl
+RUN gcloud components install kubectl --quiet
 
 RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
      apk update && \


### PR DESCRIPTION
Rebuild  the image to get the latest versions of all tools in, added versioning on the build. Created and pushed the images with tags: 1 and 1.0.0. Maybe we can add some ci on this at some point.