### PR TITLE
Update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,18 @@
 FROM google/cloud-sdk:alpine
 
-ENV VAULT_VERSION=0.11.0
+ENV VAULT_VERSION=1.5.3
 
 RUN gcloud components install kubectl
 
-RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
-     apk update && \
-     apk add --no-cache make gcc g++ python jq docker tar consul-template@testing nodejs nodejs-npm bash openssl postgresql mariadb-client git py-pip
-
-RUN pip install docker-compose~=1.23.0
+RUN apk update && \
+    apk add --no-cache make gcc g++ python jq docker tar nodejs nodejs-npm bash openssl postgresql mariadb-client git
 
 ADD https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip /tmp
 
 WORKDIR /tmp
-RUN unzip vault_${VAULT_VERSION}_linux_amd64.zip && mv vault /usr/local/bin
-RUN chmod +x /usr/local/bin/vault
+RUN unzip vault_${VAULT_VERSION}_linux_amd64.zip && \
+    mv vault /usr/local/bin && \
+    chmod +x /usr/local/bin/vault
 
 # Install HELM
 RUN bash -c "$(curl -sS https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get)"


### PR DESCRIPTION
The image we were using had super old versions of everything, including Cloud SDK which we needed up-to-date for deploying to Cloud Run.  
I took the chance and updated the whole image.  

Would be interesting to know which packages we are actually using for it, as I see things like `nodejs`, `postgres`, `mariadb-client`, because the image is hovering 3GB (uncompressed).